### PR TITLE
SCT-3234 Char replacement 110223

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,43 +6,8 @@ MAINTAINER KBase Developer
 # install line here, a git checkout to download code, or run any other
 # installation scripts.
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y wget
-
-RUN conda install -c conda-forge phantomjs
-
-RUN pip install --upgrade pip && \
-    pip install scipy && \
-    pip install bokeh && \
-    pip install selenium
-
-RUN wget --quiet https://github.com/bbuchfink/diamond/releases/download/v2.0.9/diamond-linux64.tar.gz && \
-    tar -zxf diamond-linux64.tar.gz diamond && \
-    mv diamond /usr/bin/diamond && \
-    diamond version
-
-RUN DEBIAN_FRONTEND=noninteractive apt-get install -y grace && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y mcl
-
-RUN apt-get install -y mafft && \
-    mafft --version
-    
-RUN apt-get install -y fasttree && \
-    FastTree -expert
-
-RUN mkdir -p /kb/deps
-WORKDIR /kb/deps
-
-RUN wget --quiet https://github.com/davidemms/OrthoFinder/releases/download/2.5.2/OrthoFinder_source.tar.gz && \
-    tar -zxf OrthoFinder_source.tar.gz && \
-    mv OrthoFinder_source /usr/bin/orthofinder
-
-# Using a fork with fixes for Python 3
-RUN git clone https://github.com/samseaver/pygrace.git && \
-    cd pygrace && \
-    mv PyGrace /opt/conda3/lib/python3.8/site-packages/PyGrace
-
-# Loading PlantSEED data
-RUN git clone -b kbase_release https://github.com/ModelSEED/PlantSEED /kb/module/PlantSEED
+COPY scripts/install_dependencies.sh /kb/module/scripts/
+RUN /kb/module//scripts/install_dependencies.sh
 
 # -----------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kbase/sdkbase2:python
+FROM kbase/sdkpython:3.8.10
 MAINTAINER KBase Developer
 # -----------------------------------------
 # In this section, you can install any system dependencies required
@@ -27,7 +27,6 @@ RUN apt-get install -y mafft && \
     mafft --version
     
 RUN apt-get install -y fasttree && \
-    ln -s /usr/bin/fasttree /usr/bin/FastTree && \
     FastTree -expert
 
 RUN mkdir -p /kb/deps
@@ -35,12 +34,12 @@ WORKDIR /kb/deps
 
 RUN wget --quiet https://github.com/davidemms/OrthoFinder/releases/download/2.5.2/OrthoFinder_source.tar.gz && \
     tar -zxf OrthoFinder_source.tar.gz && \
-    mv OrthoFinder_source /kb/deployment/bin/orthofinder
+    mv OrthoFinder_source /usr/bin/orthofinder
 
 # Using a fork with fixes for Python 3
 RUN git clone https://github.com/samseaver/pygrace.git && \
     cd pygrace && \
-    mv PyGrace /kb/deployment/lib/PyGrace
+    mv PyGrace /opt/conda3/lib/python3.8/site-packages/PyGrace
 
 # Loading PlantSEED data
 RUN git clone -b kbase_release https://github.com/ModelSEED/PlantSEED /kb/module/PlantSEED

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,12 @@
 # kb_orthofinder release notes
 =========================================
 
+2.1.2
+-----
+* OrthoFinder will replace a few special characters within the protein
+  ids with the underscore character, so this fix will make sure that 
+  the original protein ids can be retrieved.
+
 2.1.1
 -----
 * Major bug fix to handle possible missing links between features,

--- a/dependencies.json
+++ b/dependencies.json
@@ -1,7 +1,7 @@
 [ {
   "module_name" : "DataFileUtil",
-  "type" : "core",
-  "file_path" : "https://raw.githubusercontent.com/kbaseapps/DataFileUtil/master/DataFileUtil.spec"
+  "type" : "sdk",
+  "version_tag" : "release"
 }, {
   "module_name" : "GenomeFileUtil",
   "type" : "sdk",

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -16,7 +16,7 @@ scratch = /kb/module/work/tmp
 # pre-determined OrthoFinder results.
 # If skip_refdata is set to 0 for tests, the App will
 # use the reference data instead
-skip_refdata = 1
+skip_refdata = 0
 
 # test_data can either be OrthoFinder_Test_Reference or OrthoFinder_Test_Result_Reference
 # the former containing species-species BLAST results

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -27,7 +27,8 @@ testing = 0
 # $ cd test_local/workdir/test_data/
 # $ tar -czf OrthoFinder_Test_Result_Reference.tar.gz OrthoFinder_Test_Result_Reference
 # $ scp data/OrthoFinder_Test_Result_Reference.tar.gz gce:~/public_html/KBase_App_Files/
-test_data = OrthoFinder_Test_Result_Reference
+# test_data = OrthoFinder_Test_Result_Reference
+test_data = OrthoFinder_Test_Reference
 
 # If pre-computed protein families (i.e. OrthoFinder_Test_Result_Reference)
 # are being used, set run_orthofinder to zero to skip that step and speed up

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -16,7 +16,7 @@ scratch = /kb/module/work/tmp
 # pre-determined OrthoFinder results.
 # If testing is set to 0 for tests, the App will
 # use the reference data instead
-testing = 0
+testing = 1
 
 # test_data can either be OrthoFinder_Test_Reference or OrthoFinder_Test_Result_Reference
 # the former containing species-species BLAST results

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -16,7 +16,7 @@ scratch = /kb/module/work/tmp
 # pre-determined OrthoFinder results.
 # If testing is set to 0 for tests, the App will
 # use the reference data instead
-testing = 1
+skip_refdata = 1
 
 # test_data can either be OrthoFinder_Test_Reference or OrthoFinder_Test_Result_Reference
 # the former containing species-species BLAST results
@@ -27,7 +27,7 @@ testing = 1
 # $ cd test_local/workdir/test_data/
 # $ tar -czf OrthoFinder_Test_Result_Reference.tar.gz OrthoFinder_Test_Result_Reference
 # $ scp data/OrthoFinder_Test_Result_Reference.tar.gz gce:~/public_html/KBase_App_Files/
-# test_data = OrthoFinder_Test_Result_Reference
+# test_data = OrthoFinder_Test_Result_Reference NB: current test result won't return hits
 test_data = OrthoFinder_Test_Reference
 
 # If pre-computed protein families (i.e. OrthoFinder_Test_Result_Reference)

--- a/deploy.cfg
+++ b/deploy.cfg
@@ -14,7 +14,7 @@ scratch = /kb/module/work/tmp
 # These configuration key-value pairs are only used
 # if the "families_path" parameter is used for
 # pre-determined OrthoFinder results.
-# If testing is set to 0 for tests, the App will
+# If skip_refdata is set to 0 for tests, the App will
 # use the reference data instead
 skip_refdata = 1
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    2.1.1
+    2.1.2
 
 owners:
     [seaver]

--- a/lib/installed_clients/DataFileUtilClient.py
+++ b/lib/installed_clients/DataFileUtilClient.py
@@ -23,15 +23,21 @@ class DataFileUtil(object):
             self, url=None, timeout=30 * 60, user_id=None,
             password=None, token=None, ignore_authrc=False,
             trust_all_ssl_certificates=False,
-            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login'):
+            auth_svc='https://ci.kbase.us/services/auth/api/legacy/KBase/Sessions/Login',
+            service_ver='release',
+            async_job_check_time_ms=100, async_job_check_time_scale_percent=150, 
+            async_job_check_max_time_ms=300000):
         if url is None:
             raise ValueError('A url is required')
-        self._service_ver = None
+        self._service_ver = service_ver
         self._client = _BaseClient(
             url, timeout=timeout, user_id=user_id, password=password,
             token=token, ignore_authrc=ignore_authrc,
             trust_all_ssl_certificates=trust_all_ssl_certificates,
-            auth_svc=auth_svc)
+            auth_svc=auth_svc,
+            async_job_check_time_ms=async_job_check_time_ms,
+            async_job_check_time_scale_percent=async_job_check_time_scale_percent,
+            async_job_check_max_time_ms=async_job_check_max_time_ms)
 
     def shock_to_file(self, params, context=None):
         """
@@ -69,8 +75,8 @@ class DataFileUtil(object):
            parameter "file_path" of String, parameter "size" of Long,
            parameter "attributes" of mapping from String to unspecified object
         """
-        return self._client.call_method('DataFileUtil.shock_to_file',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.shock_to_file',
+                                    [params], self._service_ver, context)
 
     def shock_to_file_mass(self, params, context=None):
         """
@@ -108,8 +114,8 @@ class DataFileUtil(object):
            parameter "file_path" of String, parameter "size" of Long,
            parameter "attributes" of mapping from String to unspecified object
         """
-        return self._client.call_method('DataFileUtil.shock_to_file_mass',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.shock_to_file_mass',
+                                    [params], self._service_ver, context)
 
     def file_to_shock(self, params, context=None):
         """
@@ -154,23 +160,59 @@ class DataFileUtil(object):
            parameter "type" of String, parameter "remote_md5" of String,
            parameter "node_file_name" of String, parameter "size" of String
         """
-        return self._client.call_method('DataFileUtil.file_to_shock',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.file_to_shock',
+                                    [params], self._service_ver, context)
 
     def unpack_file(self, params, context=None):
         """
         Using the same logic as unpacking a Shock file, this method will cause
         any bzip or gzip files to be uncompressed, and then unpack tar and zip
-        archive files (uncompressing gzipped or bzipped archive files if 
-        necessary). If the file is an archive, it will be unbundled into the 
+        archive files (uncompressing gzipped or bzipped archive files if
+        necessary). If the file is an archive, it will be unbundled into the
         directory containing the original output file.
         :param params: instance of type "UnpackFileParams" -> structure:
            parameter "file_path" of String
         :returns: instance of type "UnpackFileResult" -> structure: parameter
            "file_path" of String
         """
-        return self._client.call_method('DataFileUtil.unpack_file',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.unpack_file',
+                                    [params], self._service_ver, context)
+
+    def unpack_files(self, params, context=None):
+        """
+        Using the same logic as unpacking a Shock file, this method will cause
+        any bzip or gzip files to be uncompressed, and then unpack tar and zip
+        archive files (uncompressing gzipped or bzipped archive files if 
+        necessary). If the file is an archive, it will be unbundled into the 
+        directory containing the original output file.
+        The ordering of the input and output files is preserved in the input and output lists.
+        :param params: instance of list of type "UnpackFilesParams" (Input
+           parameters for the unpack_files function. Required parameter:
+           file_path - the path to the file to unpack. The file will be
+           unpacked into the file's parent directory. Optional parameter:
+           unpack - either 'uncompress' or 'unpack'. 'uncompress' will cause
+           any bzip or gzip files to be uncompressed. 'unpack' will behave
+           the same way, but it will also unpack tar and zip archive files
+           (uncompressing gzipped or bzipped archive files if necessary). If
+           'uncompress' is specified and an archive file is encountered, an
+           error will be thrown. If the file is an archive, it will be
+           unbundled into the directory containing the original output file.
+           Defaults to 'unpack'. Note that if the file name (either as
+           provided by the user or by Shock) without the a decompression
+           extension (e.g. .gz, .zip or .tgz -> .tar) points to an existing
+           file and unpack is specified, that file will be overwritten by the
+           decompressed Shock file.) -> structure: parameter "file_path" of
+           String, parameter "unpack" of String
+        :returns: instance of list of type "UnpackFilesResult" (Output
+           parameters for the unpack_files function. file_path - the path to
+           either a) the unpacked file or b) in the case of archive files,
+           the path to the original archive file, possibly uncompressed, or
+           c) in the case of regular files that don't need processing, the
+           path to the input file.) -> structure: parameter "file_path" of
+           String
+        """
+        return self._client.run_job('DataFileUtil.unpack_files',
+                                    [params], self._service_ver, context)
 
     def pack_file(self, params, context=None):
         """
@@ -196,8 +238,8 @@ class DataFileUtil(object):
            pack_file function. file_path - the path to the packed file.) ->
            structure: parameter "file_path" of String
         """
-        return self._client.call_method('DataFileUtil.pack_file',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.pack_file',
+                                    [params], self._service_ver, context)
 
     def package_for_download(self, params, context=None):
         """
@@ -228,8 +270,8 @@ class DataFileUtil(object):
            "shock_id" of String, parameter "node_file_name" of String,
            parameter "size" of String
         """
-        return self._client.call_method('DataFileUtil.package_for_download',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.package_for_download',
+                                    [params], self._service_ver, context)
 
     def file_to_shock_mass(self, params, context=None):
         """
@@ -275,8 +317,8 @@ class DataFileUtil(object):
            parameter "type" of String, parameter "remote_md5" of String,
            parameter "node_file_name" of String, parameter "size" of String
         """
-        return self._client.call_method('DataFileUtil.file_to_shock_mass',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.file_to_shock_mass',
+                                    [params], self._service_ver, context)
 
     def copy_shock_node(self, params, context=None):
         """
@@ -302,8 +344,8 @@ class DataFileUtil(object):
            of String, parameter "type" of String, parameter "remote_md5" of
            String
         """
-        return self._client.call_method('DataFileUtil.copy_shock_node',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.copy_shock_node',
+                                    [params], self._service_ver, context)
 
     def own_shock_node(self, params, context=None):
         """
@@ -337,8 +379,8 @@ class DataFileUtil(object):
            of String, parameter "type" of String, parameter "remote_md5" of
            String
         """
-        return self._client.call_method('DataFileUtil.own_shock_node',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.own_shock_node',
+                                    [params], self._service_ver, context)
 
     def ws_name_to_id(self, name, context=None):
         """
@@ -346,8 +388,8 @@ class DataFileUtil(object):
         :param name: instance of String
         :returns: instance of Long
         """
-        return self._client.call_method('DataFileUtil.ws_name_to_id',
-                                        [name], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.ws_name_to_id',
+                                    [name], self._service_ver, context)
 
     def save_objects(self, params, context=None):
         """
@@ -355,7 +397,7 @@ class DataFileUtil(object):
         The objects will be sorted prior to saving to avoid the Workspace sort memory limit.
         Note that if the object contains workspace object refs in mapping keys that may cause
         the Workspace to resort the data. To avoid this, convert any refs in mapping keys to UPA
-        format (e.g. #/#/#, where # is a positive integer). 
+        format (e.g. #/#/#, where # is a positive integer).
         If the data is very large, using the WSLargeDataIO SDK module is advised.
         Saving over a deleted object undeletes it.
         :param params: instance of type "SaveObjectsParams" (Input parameters
@@ -407,8 +449,8 @@ class DataFileUtil(object):
            parameter "chsum" of String, parameter "size" of Long, parameter
            "meta" of mapping from String to String
         """
-        return self._client.call_method('DataFileUtil.save_objects',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.save_objects',
+                                    [params], self._service_ver, context)
 
     def get_objects(self, params, context=None):
         """
@@ -453,8 +495,8 @@ class DataFileUtil(object):
            parameter "chsum" of String, parameter "size" of Long, parameter
            "meta" of mapping from String to String
         """
-        return self._client.call_method('DataFileUtil.get_objects',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.get_objects',
+                                    [params], self._service_ver, context)
 
     def versions(self, context=None):
         """
@@ -462,8 +504,8 @@ class DataFileUtil(object):
         :returns: multiple set - (1) parameter "wsver" of String, (2)
            parameter "shockver" of String
         """
-        return self._client.call_method('DataFileUtil.versions',
-                                        [], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.versions',
+                                    [], self._service_ver, context)
 
     def download_staging_file(self, params, context=None):
         """
@@ -481,8 +523,8 @@ class DataFileUtil(object):
            scratch area path) -> structure: parameter "copy_file_path" of
            String
         """
-        return self._client.call_method('DataFileUtil.download_staging_file',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.download_staging_file',
+                                    [params], self._service_ver, context)
 
     def download_web_file(self, params, context=None):
         """
@@ -496,9 +538,9 @@ class DataFileUtil(object):
            download_web_file function. copy_file_path: copied file scratch
            area path) -> structure: parameter "copy_file_path" of String
         """
-        return self._client.call_method('DataFileUtil.download_web_file',
-                                        [params], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.download_web_file',
+                                    [params], self._service_ver, context)
 
     def status(self, context=None):
-        return self._client.call_method('DataFileUtil.status',
-                                        [], self._service_ver, context)
+        return self._client.run_job('DataFileUtil.status',
+                                    [], self._service_ver, context)

--- a/lib/kb_orthofinder/kb_orthofinderImpl.py
+++ b/lib/kb_orthofinder/kb_orthofinderImpl.py
@@ -59,7 +59,7 @@ class kb_orthofinder:
                 y=float(y)
                 x=float(x)
 
-                if(group not in Data):
+                if group not in Data:
                     Data[group]=list()
 
                 Data[group].append((x,y))
@@ -81,17 +81,17 @@ class kb_orthofinder:
         clustered_sequences=dict()
         for i in range(len(features)-1):
             for j in range(1,len(features)):
-                if(i>=j):
+                if i>=j:
                     continue
 
                 Spp1=features[i].split("||")[0]
                 Spp2=features[j].split("||")[0]
-                if(Spp1 == features[i]):
+                if Spp1 == features[i]:
                     Spp1 = "_".join(features[i].split("_")[0:-1])
-                if(Spp2 == features[j]):
+                if Spp2 == features[j]:
                     Spp2 = "_".join(features[j].split("_")[0:-1])
 
-                if(Spp1 == Spp2):
+                if Spp1 == Spp2:
                     continue
 
                 Seq1 = cluster[features[i]]
@@ -99,10 +99,10 @@ class kb_orthofinder:
 
                 AA_Match=0.0;
                 for k in range(len(Seq1)):
-                    if(Seq1[k] == "-" or Seq2[k] == "-"):
+                    if Seq1[k] == "-" or Seq2[k] == "-":
                         continue
 
-                    if(Seq1[k] == Seq2[k]):
+                    if Seq1[k] == Seq2[k]:
                         AA_Match+=1.0
 
                 Seq1=Seq1.replace('-','')
@@ -112,12 +112,12 @@ class kb_orthofinder:
                 ID2=AA_Match/len(Seq2)
                 Avg = "{0:.6f}".format((ID1+ID2)/2.0)
 
-                if("Athaliana" in Spp1):
-                    if(features[j] not in clustered_sequences):
+                if "Athaliana" in Spp1:
+                    if features[j] not in clustered_sequences:
                         clustered_sequences[features[j]]=dict()
                     clustered_sequences[features[j]][features[i]]=Avg
-                elif("Athaliana" in Spp2):
-                    if(features[i] not in clustered_sequences):
+                elif "Athaliana" in Spp2:
+                    if features[i] not in clustered_sequences:
                         clustered_sequences[features[i]]=dict()
                     clustered_sequences[features[i]][features[j]]=Avg
 
@@ -128,22 +128,22 @@ class kb_orthofinder:
         top_orthologs = dict()
         for ortholog in (cluster.keys()):
             
-            if(cluster[ortholog] not in top_orthologs):
+            if cluster[ortholog] not in top_orthologs:
                 top_orthologs[cluster[ortholog]]=dict()
             top_orthologs[cluster[ortholog]][ortholog]=1
 
         top_ortholog_seqid="0.00"
         for seq_id in (top_orthologs.keys()):
-            if(float(seq_id)>float(top_ortholog_seqid)):
+            if float(seq_id)>float(top_ortholog_seqid):
                 top_ortholog_seqid=seq_id
 
         #Key to controlling the propagation of annotation
         #Is the sequence identity of the highest-scoring ortholog good enough?
-        if(float(top_ortholog_seqid) < threshold):
+        if float(top_ortholog_seqid) < threshold:
             return (None,"Unannotated 1: LESS_THAN_THRESHOLD",0.0)
 
         top_ortholog=""
-        if(len(top_orthologs[top_ortholog_seqid])==1):
+        if len(top_orthologs[top_ortholog_seqid])==1:
             top_ortholog = list(top_orthologs[top_ortholog_seqid].keys())[0]
         else:
             #There are multiple Arabidopsis orthologs that have the same level of seq. id
@@ -154,7 +154,7 @@ class kb_orthofinder:
             for ortholog in (top_orthologs[top_ortholog_seqid].keys()):
                 function="Unannotated"
                 ortholog_gene = ".".join(ortholog.split('.')[0:-1])
-                if(ortholog_gene not in plantseed_curation):
+                if ortholog_gene not in plantseed_curation:
                     function = "Unannotated 2: ARA_GENE_NOT_IN_CURATION"
                     Unannotated = True
                 else:
@@ -170,33 +170,33 @@ class kb_orthofinder:
             # 3) if 2 functions, and none is "Unannotated" or > 2 functions, 
             #    its ambiguous, return without doing anything
             is_ambiguous=False
-            if(len(Multi_Functions.keys())==1):
+            if len(Multi_Functions.keys())==1:
                 top_ortholog = list(top_orthologs[top_ortholog_seqid].keys())[0]
-            elif(len(Multi_Functions.keys())==2):
-                if(Unannotated is True):
+            elif len(Multi_Functions.keys())==2:
+                if Unannotated is True:
                     for ortholog in (top_orthologs[top_ortholog_seqid].keys()):
                         ortholog_gene = ".".join(ortholog.split('.')[0:-1])
-                        if(ortholog_gene not in plantseed_curation):
+                        if ortholog_gene not in plantseed_curation:
                             continue
                         top_ortholog = ortholog
                         break
                 else:
                     functions_list = sorted(list(Multi_Functions.keys()))
-                    if( functions_list[0] in functions_list[1] or \
-                            functions_list[1] in functions_list[0] ):
+                    if functions_list[0] in functions_list[1] or \
+                            functions_list[1] in functions_list[0]:
                         top_ortholog = list(top_orthologs[top_ortholog_seqid].keys())[0]
                     else:
                         is_ambiguous=True
             else:
                 is_ambiguous=True
 
-            if(is_ambiguous is True):
+            if is_ambiguous is True:
                 #Ambiguously curated top orthologs, so pass
                 print("Ambiguous Functions: ","||".join(list(Multi_Functions.keys())))
                 return (None,"Unannotated 3: AMB_HIT",0.0)
 
         top_ortholog_gene = ".".join(top_ortholog.split('.')[0:-1])
-        if(top_ortholog_gene in plantseed_curation):
+        if top_ortholog_gene in plantseed_curation:
             return (top_ortholog,plantseed_curation[top_ortholog_gene]['function'],top_ortholog_seqid)
         else:
             return (None,"Unannotated 4: NO_ARA_HIT",0.0)
@@ -210,11 +210,11 @@ class kb_orthofinder:
         self.workspaceURL = config['workspace-url']
 
         self.testing = False
-        if(config['testing'] == '1'):
+        if config['testing'] == '1':
             self.testing=True
 
         self.runOrthoFinder = True
-        if(config['run_orthofinder'] == '0'):
+        if config['run_orthofinder'] == '0':
             self.runOrthoFinder=False
             
         self.token = os.environ['KB_AUTH_TOKEN']
@@ -247,14 +247,14 @@ class kb_orthofinder:
 
         #Need to extract longest CDS, but only if CDSs available
         use_cds=1
-        if(len(plant_genome['data']['cdss'])==0):
+        if len(plant_genome['data']['cdss'])==0:
             use_cds=0
-            if(len(plant_genome['data']['features'])==0):
+            if len(plant_genome['data']['features'])==0:
                 raise Exception("The genome does not contain any CDSs or features!")
 
         #Now need to be able to retrieve cds entity
         child_cds_index = dict()
-        if(use_cds==1):
+        if use_cds==1:
             child_cds_index = dict([(f['id'], i) for i, f in enumerate(plant_genome['data']['cdss'])])
 
         # If use_cds==1 iterate through features, iterate through CDSs, find longest sequence, use parent mRNA ID    
@@ -262,20 +262,20 @@ class kb_orthofinder:
         self.log("Collecting protein sequences")
         sequences_dict=dict()
         for ftr in plant_genome['data']['features']:
-            if(use_cds==0 and len(ftr['protein_translation'])>0):
+            if use_cds==0 and len(ftr['protein_translation'])>0:
                 sequences_dict[ftr['id']]=ftr['protein_translation']
-            if(use_cds==1 and 'cdss' in ftr):
+            if use_cds==1 and 'cdss' in ftr:
                 longest_sequence=""
                 longest_sequence_id=""
                 for cds_id in ftr['cdss']:
                     sequence = plant_genome['data']['cdss'][child_cds_index[cds_id]]['protein_translation']
-                    if(len(sequence) > len(longest_sequence)):
+                    if len(sequence) > len(longest_sequence):
                         longest_sequence = sequence
                         longest_sequence_id = cds_id
-                if(len(longest_sequence)>0):
+                if len(longest_sequence)>0:
                     sequences_dict[longest_sequence_id]=longest_sequence
 
-        if(len(sequences_dict)==0):
+        if len(sequences_dict)==0:
             raise Exception("The genome does not contain any protein sequences!")
 
         # We have a problem with how OrthoFinder arbitrarily replaces 'special' characters in identifiers:
@@ -301,9 +301,8 @@ class kb_orthofinder:
         uuid_string = "family_data_"+str(uuid.uuid4())
         family_file_path=os.path.join(self.scratch,uuid_string)
 
-        if(self.testing is True):
-            if('families_path' in input and os.path.isdir(input['families_path'])):
-                #family_file_path = input['families_path']
+        if self.testing is True:
+            if 'families_path' in input and os.path.isdir(input['families_path']):
                 self.log("Copying Test Families at "+family_file_path)
                 shutil.copytree(input['families_path'],family_file_path)
         else:
@@ -321,12 +320,12 @@ class kb_orthofinder:
             #Code plagarized from https://github.com/biopython/biopython/blob/master/Bio/SeqIO/FastaIO.py
             for seq_id in sequences_dict:
                 #printing smaller set for testing purposes
-                if(self.testing is True):
+                if self.testing is True:
                     testing_count = testing_count -1
                 fasta_handle.write(">"+seq_id+"\n")
                 for i in range(0, len(sequences_dict[seq_id]), 80):
                     fasta_handle.write(sequences_dict[seq_id][i:i+80]+"\n")
-                if(testing_count==0):
+                if testing_count==0:
                     break
                 
         #Building command
@@ -346,7 +345,7 @@ class kb_orthofinder:
 
         #####################################################
         output_files=list()
-        if(self.testing is False or self.runOrthoFinder is True):
+        if self.testing is False or self.runOrthoFinder is True:
             self.log("Running OrthoFinder command: "+command)
 
             pipe = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
@@ -390,11 +389,11 @@ class kb_orthofinder:
         output['fns']=list()
         for feature in plantseed_curation:
             function = plantseed_curation[feature]['function']
-            if( function not in output['fns'] ):
+            if  function not in output['fns']:
                 output['fns'].append(function)
 
             for role in plantseed_curation[feature]['roles']:
-                if(role not in Ignored_Curation):
+                if role not in Ignored_Curation:
                     PlantSEED_Roles[role]=1
 
         output['fns']=len(output['fns'])
@@ -428,23 +427,23 @@ class kb_orthofinder:
                     transcript_description = None
 
                 # anticipating if OF changed characters in ids, see above
-                if(transcript_id in alt_seq_ids_dict):
+                if transcript_id in alt_seq_ids_dict:
                     transcript_id = alt_seq_ids_dict[transcript_id]
 
                 #skip un-necessary proteins to reduce computation time
-                if("Athaliana" not in transcript_id and transcript_id not in sequences_dict):
+                if "Athaliana" not in transcript_id and transcript_id not in sequences_dict:
                     continue
 
                 seq = seq.upper()
                 family_sequences_dict[transcript_id]=seq
                 gene_id = ".".join(transcript_id.split('.')[0:-1])
-                if(gene_id in plantseed_curation):
+                if gene_id in plantseed_curation:
                     function = plantseed_curation[gene_id]['function']
                     curated_family.append(function+"|||"+transcript_id)
                     output['alignments'].append(transcript_id)
             
-            if(len(curated_family)>0):
-                if(family not in families_dict):
+            if len(curated_family)>0:
+                if family not in families_dict:
                     families_dict[family]=dict()
                 families_dict[family]['sequences']=family_sequences_dict
                 families_dict[family]['functions']=curated_family
@@ -466,14 +465,14 @@ class kb_orthofinder:
 
             for function_ortholog in families_dict[family]['functions']:
                 (function,ortholog) = function_ortholog.split("|||")
-                if(function not in functions_dict):
+                if function not in functions_dict:
                     functions_dict[function]=dict()
-                if(family not in functions_dict[function]):
+                if family not in functions_dict[function]:
                     functions_dict[function][family]={'orthologs':[],
                                                       'hits':[],
                                                       'cluster':pw_seq_id_list}
 
-                if(ortholog not in functions_dict[function][family]['orthologs']):
+                if ortholog not in functions_dict[function][family]['orthologs']:
                     functions_dict[function][family]['orthologs'].append(ortholog)
 
             for spp_ftr in sorted(pw_seq_id_list.keys()):
@@ -483,31 +482,31 @@ class kb_orthofinder:
                 ftr = spp_ftr.replace(temp_genome_name+"_","")
 
                 # Write out results
-                if(function not in functions_dict):
+                if function not in functions_dict:
                     annotate_fh.write("MISSING FUNCTION: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
                 else:
                     annotate_fh.write("FOUND FUNCTION: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
-                    if(family not in functions_dict[function]):
+                    if family not in functions_dict[function]:
                         annotate_fh.write("MISSING FAMILY: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
                     else:
                         annotate_fh.write("FOUND FAMILY: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
-                        if(ortholog not in functions_dict[function][family]['orthologs']):
+                        if ortholog not in functions_dict[function][family]['orthologs']:
                             annotate_fh.write("MISSING ORTHOLOG: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
                         else:
                             annotate_fh.write("FOUND ORTHOLOG: "+" | ".join([function,family,str(ortholog),spp_ftr])+"\n")
 
                 # Save result
-                if("Unannotated" in function):
+                if "Unannotated" in function:
                     function="Unannotated"
 
                 annotated_features_dict[ftr]=function
 
-                if(function not in found_annotations and "Unannotated" not in function):
+                if function not in found_annotations and "Unannotated" not in function:
                     found_annotations.append(function)
 
-                if(function in functions_dict and \
+                if function in functions_dict and \
                        family in functions_dict[function] and \
-                       ortholog in functions_dict[function][family]['orthologs']):
+                       ortholog in functions_dict[function][family]['orthologs']:
                     functions_dict[function][family]['hits'].append({'seqid':seqid,
                                                                      'feature':spp_ftr,
                                                                      'ortholog':ortholog})
@@ -526,7 +525,7 @@ class kb_orthofinder:
         #But, if annotating CDS, need to be able to retrieve parent feature/transcripts
         parent_feature_index = dict()
         parent_transcript_index = dict()
-        if(use_cds==1):
+        if use_cds==1:
             parent_feature_index = dict([(f['id'], i) for i, f in enumerate(plant_genome['data']['features'])])
             parent_transcript_index = dict([(f['id'], i) for i, f in enumerate(plant_genome['data']['mrnas'])])
 
@@ -535,11 +534,11 @@ class kb_orthofinder:
         # As the Phytozome genomes have CDSs, the features don't usually get annotated here
         for ftr in plant_genome['data']['features']:
             ftr['functions']=["Unannotated"]
-            if(ftr['id'] in annotated_features_dict):
+            if ftr['id'] in annotated_features_dict:
                 ftr['functions']=[annotated_features_dict[ftr['id']]]
 
             # It is possible that a gene is listed without an associated transcript
-            if('mrnas' in ftr):
+            if 'mrnas' in ftr:
                 
                 # Add annotation to transcripts
                 # As the Phytozome genomes have CDSs, the features don't usually get annotated here
@@ -553,14 +552,14 @@ class kb_orthofinder:
                     mrna_obj['functions'] = [ftr['functions'][0]]
 
                     # If it happens that the mRNA is independently annotated
-                    if(mrna in annotated_features_dict):
+                    if mrna in annotated_features_dict:
                         mrna_obj['functions'] = [annotated_features_dict[mrna]]
 
                         # Then annotate parent feature gene
                         ftr['functions']=[annotated_features_dict[mrna]]
                         
             # It is possible that a gene is listed without an associated protein
-            if('cdss' in ftr):
+            if 'cdss' in ftr:
 
                 # Add annotation to proteins
                 # As the Phytozome genomes have CDSs, the features and mrnas get annotated here
@@ -575,10 +574,10 @@ class kb_orthofinder:
 
                     # If it happens that the CDS is independently annotated
                     # Which is most likely event if using Phytozome genomes
-                    if(cds in annotated_features_dict):
+                    if cds in annotated_features_dict:
                         cds_obj['functions'] = [annotated_features_dict[cds]]
 
-                        if('parent_mrna' in cds_obj):
+                        if 'parent_mrna' in cds_obj:
                             parent_transcript_indice = parent_transcript_index[cds_obj['parent_mrna']]
                             parent_transcript_obj = plant_genome['data']['mrnas'][parent_transcript_indice]
                             parent_transcript_obj['functions'] = [annotated_features_dict[cds]]
@@ -593,11 +592,11 @@ class kb_orthofinder:
             json.dump(plant_genome, fh)
             fh.close()
 
-        if('output_genome' not in input):
+        if 'output_genome' not in input:
             input['output_genome']=input['input_genome']
 
         saved_genome=""
-        if(self.testing is True):
+        if self.testing is True:
             #wsid = self.dfu.ws_name_to_id(input['input_ws'])
             #save_result = self.dfu.save_objects({'id':wsid,'objects':[{'name':input['output_genome'],
             #                                                           'data':plant_genome['data'],
@@ -620,7 +619,7 @@ class kb_orthofinder:
             Function = Function_Comments.pop(0)
             Roles = re.split("\s*;\s+|\s+[\@\/]\s+", Function)
             for role in Roles:
-                if(role in PlantSEED_Roles):
+                if role in PlantSEED_Roles:
                     Annotated_Roles[role]=1
 
         output['hit_fns']=len(found_annotations)
@@ -741,7 +740,7 @@ class kb_orthofinder:
                           'file_links' : output_files,
                           'html_links' : html_report_list}
 
-        if(self.testing is False):
+        if self.testing is False:
             report_params['objects_created']=[{"ref":saved_genome,"description":description}]
 
             kbase_report_client = KBaseReport(self.callback_url, token=self.token)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -11,8 +11,8 @@ fi
 if [ $# -eq 0 ] ; then
   sh ./scripts/start_server.sh
 elif [ "${1}" = "test" ] ; then
-  TESTING=$(grep ^testing ./deploy.cfg | awk '{print $3}')
-  if [ "${TESTING}" = "1" ] ; then
+  USE_TEST_DATA=$(grep ^skip_refdata ./deploy.cfg | awk '{print $3}')
+  if [ "${USE_TEST_DATA}" = "1" ] ; then
     echo "Initializing test data"
     TEST_DATA=$(grep ^test_data ./deploy.cfg | awk '{print $3}')
     mkdir -p /kb/module/work/test_data
@@ -34,6 +34,8 @@ elif [ "${1}" = "test" ] ; then
 	exit 1
       fi
     fi
+  else
+    echo "Warning: Running tests without initializing test data!"
   fi
   echo "Running Tests"
   cd /kb/module

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Initialization
+apt-get update
+apt-get upgrade -y
+apt-get install -y wget
+
+# Main OrthoFinder Software
+wget --quiet https://github.com/davidemms/OrthoFinder/releases/download/2.5.2/OrthoFinder_source.tar.gz
+tar -zxf OrthoFinder_source.tar.gz
+mv OrthoFinder_source /usr/bin/orthofinder
+
+# OrthoFinder dependencies
+DEBIAN_FRONTEND=noninteractive apt-get install -y mcl
+apt-get install -y mafft
+apt-get install -y fasttree
+wget --quiet https://github.com/bbuchfink/diamond/releases/download/v2.0.9/diamond-linux64.tar.gz
+tar -zxf diamond-linux64.tar.gz diamond
+mv diamond /usr/bin/diamond
+
+# Dependcies for generating plot for main report
+DEBIAN_FRONTEND=noninteractive apt-get install -y grace
+# Using a fork with fixes for Python 3
+git clone https://github.com/samseaver/pygrace.git
+cd pygrace
+mv PyGrace /opt/conda3/lib/python3.8/site-packages/PyGrace
+
+# Loading PlantSEED data
+git clone -b kbase_release https://github.com/ModelSEED/PlantSEED /kb/module/PlantSEED
+
+# Dependencies for Bokeh JS Plots
+conda install -c conda-forge phantomjs
+pip install --upgrade pip
+pip install scipy
+pip install bokeh
+pip install selenium

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -10,16 +10,13 @@ wget --quiet https://github.com/davidemms/OrthoFinder/releases/download/2.5.2/Or
 tar -zxf OrthoFinder_source.tar.gz
 mv OrthoFinder_source /usr/bin/orthofinder
 
-# OrthoFinder dependencies
-DEBIAN_FRONTEND=noninteractive apt-get install -y mcl
-apt-get install -y mafft
-apt-get install -y fasttree
+# OrthoFinder dependencies and grace for report generation
+DEBIAN_FRONTEND=noninteractive apt-get install -y mcl grace mafft fasttree
 wget --quiet https://github.com/bbuchfink/diamond/releases/download/v2.0.9/diamond-linux64.tar.gz
 tar -zxf diamond-linux64.tar.gz diamond
 mv diamond /usr/bin/diamond
 
 # Dependcies for generating plot for main report
-DEBIAN_FRONTEND=noninteractive apt-get install -y grace
 # Using a fork with fixes for Python 3
 git clone https://github.com/samseaver/pygrace.git
 cd pygrace
@@ -31,6 +28,4 @@ git clone -b kbase_release https://github.com/ModelSEED/PlantSEED /kb/module/Pla
 # Dependencies for Bokeh JS Plots
 conda install -c conda-forge phantomjs
 pip install --upgrade pip
-pip install scipy
-pip install bokeh
-pip install selenium
+pip install scipy bokeh selenium

--- a/test/kb_orthofinder_genome_test.tmp
+++ b/test/kb_orthofinder_genome_test.tmp
@@ -52,11 +52,11 @@ class kb_orthofinderTest(unittest.TestCase):
         cls.serviceImpl = kb_orthofinder(cls.cfg)
         cls.scratch = cls.cfg['scratch']
 
-        cls.testing = False
+        cls.skip_refdata = False
         cls.test_data = "OrthoFinder_Phytozome_Reference"
         
-        if(cls.cfg['testing']=="1"):
-            cls.testing = True
+        if(cls.cfg['skip_refdata']=="1"):
+            cls.skip_refdata = True
             cls.test_data = cls.cfg['test_data']
             
         cls.callback_url = os.environ['SDK_CALLBACK_URL']
@@ -84,7 +84,7 @@ class kb_orthofinderTest(unittest.TestCase):
     @classmethod
     def prepare_data(cls):
 
-        if(cls.testing is False):
+        if(cls.skip_refdata is False):
             cls.gff_filename = 'Test_v1.0.gene.gff3.gz'
             cls.gff_path = os.path.join(cls.scratch, cls.gff_filename)
             shutil.copy(os.path.join("/kb", "module", "data", cls.gff_filename), cls.gff_path)

--- a/test/kb_orthofinder_genome_test.tmp
+++ b/test/kb_orthofinder_genome_test.tmp
@@ -25,7 +25,6 @@ class kb_orthofinderTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        print("IS THIS HAPPENING?!")
         token = environ.get('KB_AUTH_TOKEN', None)
         config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
         cls.cfg = {}
@@ -72,19 +71,9 @@ class kb_orthofinderTest(unittest.TestCase):
         if hasattr(cls, 'wsName'):
             cls.wsClient.delete_workspace({'workspace': cls.wsName})
             print('Test workspace was deleted')
-#            print('Test workspace '+cls.wsName+' was not deleted')
 
     def getWsClient(self):
         return self.__class__.wsClient
-
-    def getWsName(self):
-        if hasattr(self.__class__, 'wsName'):
-            return self.__class__.wsName
-        suffix = int(time.time() * 1000)
-        wsName = "test_kb_orthofinder_" + str(suffix)
-        ret = self.getWsClient().create_workspace({'workspace': wsName})  # noqa
-        self.__class__.wsName = wsName
-        return wsName
 
     def getImpl(self):
         return self.__class__.serviceImpl
@@ -106,44 +95,24 @@ class kb_orthofinderTest(unittest.TestCase):
 
             cls.tr_filename = cls.test_data+'.tar.gz'
             cls.data_path = os.path.join(cls.scratch, cls.tr_filename)
-            # shutil.copy(os.path.join("/kb", "module", "data", cls.tr_filename), cls.data_path)
-            
         else:
             cls.data_path = os.path.join(cls.scratch, "../", "test_data", cls.test_data)
 
-    def loadFakeGenome(cls):
-        
-        input_params = {
-            'fasta_file': {'path': cls.fa_path},
-            'gff_file': {'path': cls.gff_path},
-            'genome_name': cls.genome,
-            'workspace_name': cls.getWsName(),
-            'source': 'Phytozome',
-            'type': 'Reference',
-            'scientific_name': 'Populus trichocarpa'
-        }
-
-        result = cls.gfu.fasta_gff_to_genome(input_params)
-
     # NOTE: According to Python unittest naming rules test method names should start from 'test'. # noqa
-    def test_annotate_sunflower_transcripts(self):
+    def test_annotate_user_transcripts(self):
 
         # The commented out values are for testing a large and close relative
         input_ws = "Phytozome_Genomes"
         input_ws = "seaver:narrative_1538440679496"
         input_genome = "Hannuus_r1.2"
         input_genome = "Helianthus_annuus_RefSeq"
-        
+        input_ws = "Test"
+        input_genome = "Cocos"
+
         ret = self.getImpl().annotate_plant_transcripts(self.getContext(), {'input_ws' : input_ws,
                                                                             'input_genome' : input_genome,
                                                                             'families_path' : self.data_path,
                                                                             'threshold' : 0.55})
 
         print("RESULT: ",ret[0])
-        #self.assertEqual(ret[0]['transcripts'],1443)
-        #self.assertEqual(ret[0]['alignments'],1204)
-        #self.assertEqual(ret[0]['ftrs'],975)
-        #self.assertEqual(ret[0]['fns'],819)
-        #self.assertEqual(ret[0]['hit_ftrs'],63)
-        #self.assertEqual(ret[0]['hit_fns'],38)
         pass

--- a/test/kb_orthofinder_server_test.py
+++ b/test/kb_orthofinder_server_test.py
@@ -121,21 +121,23 @@ class kb_orthofinderTest(unittest.TestCase):
                         'input_genome' : input_genome,
                         'threshold' : 0.55}
 
-        if(self.cfg['testing'] == 1):
+        if(self.cfg['testing'] == '1'):
             # DFU hangs on the large archive so we changed it so it's done
             # during test initialization in scripts/entrypoint.sh
             # self.tr_path = os.path.join("/kb", "module", "data", self.test_data+'.tar.gz')
             # self.dfu.unpack_file({'file_path' : self.tr_path})
-            tr_path = os.path.join("/kb", "module", "data", self.test_data)
+            tr_path = os.path.join("/kb", "module", "work", "test_data", self.test_data)
             input_params['families_path'] = tr_path
 
         ret = self.getImpl().annotate_plant_transcripts(self.getContext(), input_params)
 
-        print("RESULT: ",ret[0])
+        print("\nRESULT: ",ret[0])
+	# from Test_Reference (and not Test_Result_Reference)
+	# RESULT:  {'ftrs': 975, 'fns': 824, 'transcripts': 1449, 'alignments': 1221, 'hit_fns': 9, 'hit_ftrs': 12, 'cur_roles': 594, 'hit_roles': 8}
         self.assertEqual(ret[0]['transcripts'],1449)
-        self.assertEqual(ret[0]['alignments'],1427)
+        self.assertEqual(ret[0]['alignments'],1221)
         self.assertEqual(ret[0]['ftrs'],975)
         self.assertEqual(ret[0]['fns'],824)
-        self.assertEqual(ret[0]['hit_ftrs'],72)
-        self.assertEqual(ret[0]['hit_fns'],39)
+        self.assertEqual(ret[0]['hit_ftrs'],12)
+        self.assertEqual(ret[0]['hit_fns'],9)
         pass

--- a/test/kb_orthofinder_server_test.py
+++ b/test/kb_orthofinder_server_test.py
@@ -121,7 +121,7 @@ class kb_orthofinderTest(unittest.TestCase):
                         'input_genome' : input_genome,
                         'threshold' : 0.55}
 
-        if(self.cfg['testing'] == '1'):
+        if(self.cfg['skip_refdata'] == '1'):
             # DFU hangs on the large archive so we changed it so it's done
             # during test initialization in scripts/entrypoint.sh
             # self.tr_path = os.path.join("/kb", "module", "data", self.test_data+'.tar.gz')
@@ -140,4 +140,3 @@ class kb_orthofinderTest(unittest.TestCase):
         self.assertEqual(ret[0]['fns'],824)
         self.assertEqual(ret[0]['hit_ftrs'],12)
         self.assertEqual(ret[0]['hit_fns'],9)
-        pass


### PR DESCRIPTION
I found out OrthoFinder will implicitly replace a few special characters in the identifiers used in a genome with an underscore, see here for an example:

https://github.com/davidemms/OrthoFinder/blob/master/scripts_of/util.py#L181

This of course affected the ability of the App to match the identifiers in the OF output with those in the originating genomes, so this fix is an attempt to find possibly affected identifiers

